### PR TITLE
korrekte Darstellung von XOR in KNF

### DIFF
--- a/Vorlesungen/lecture-17.tex
+++ b/Vorlesungen/lecture-17.tex
@@ -522,7 +522,7 @@ F\vee(G\wedge H) &\mapsto (F\vee G)\wedge (F\vee H)
 & {}\wedge{}  \big(\neg W(x_2)\vee(W(x_3) \vee L(x_4))\big)\\
 & {}\wedge{}  \big(\neg L(x_5)\vee(\neg W(f_6(x_1,x_2,x_3,x_4,x_5)) \wedge \neg L(f_7(x_1,x_2,x_3,x_4,x_5)))\big)\Big)\\\pause\pause
 {}\equiv{} & \forall x_1,x_2,x_3,x_4,x_5.\\
-& \Big((W(x_1)\vee L(x_1))\wedge(\neg L(x_1)\vee L(x_1))\\
+& \Big((W(x_1)\vee L(x_1))\wedge(\neg W(x_1)\vee \neg L(x_1))\\
 & {}\wedge (W(x_1)\vee \neg W(x_1))\wedge(\neg L(x_1)\vee \neg W(x_1))\big)\\
 & {}\wedge{}  \big(\neg W(x_2)\vee(W(x_3) \vee L(x_4))\big)\\
 & {}\wedge{}  \hi{4-}{\big(\neg L(x_5)\vee(\neg W(f_6(x_1,x_2,x_3,x_4,x_5)) \wedge \neg L(f_7(x_1,x_2,x_3,x_4,x_5)))\big)}\Big)\\\pause\pause


### PR DESCRIPTION
`W and !L or !W and L = W xor L = (W or L) and (!W or !L)` soweit ich das erkennen kann.

Die derzeitige Formel beinhaltet auf jeden Fall redundante Terme mit `L or !L`.