### PR TITLE
PCP-Def fix

### DIFF
--- a/Vorlesungen/lecture-05.tex
+++ b/Vorlesungen/lecture-05.tex
@@ -300,7 +300,7 @@ Stiller Vordenker von Gödel und Turing
 \narrowcentering{$\left[\begin{matrix}x_1\\y_1\end{matrix}\right]\quad\ldots\quad\left[\begin{matrix}x_k\\y_k\end{matrix}\right]$}\\[1ex]
 über einem Alphabet $\Sigma^*$.\\[1ex]
 \emph{Frage:} Gibt es eine Folge von Zahlen $i_1,\ldots,i_\ell$, so dass gilt\\[1ex]
-\narrowcentering{$x_{i_1} \cdots x_{i_k} = y_{i_1} \cdots y_{i_k}$,}\\[1ex]
+\narrowcentering{$x_{i_1} \cdots x_{i_l} = y_{i_1} \cdots y_{i_l}$,}\\[1ex]
 wobei $\ell>0$ ist und $i_j\in\{1,\ldots,k\}$ für alle $j=1,\ldots,\ell$?
 }
 

--- a/Vorlesungen/lecture-05.tex
+++ b/Vorlesungen/lecture-05.tex
@@ -300,7 +300,7 @@ Stiller Vordenker von Gödel und Turing
 \narrowcentering{$\left[\begin{matrix}x_1\\y_1\end{matrix}\right]\quad\ldots\quad\left[\begin{matrix}x_k\\y_k\end{matrix}\right]$}\\[1ex]
 über einem Alphabet $\Sigma^*$.\\[1ex]
 \emph{Frage:} Gibt es eine Folge von Zahlen $i_1,\ldots,i_\ell$, so dass gilt\\[1ex]
-\narrowcentering{$x_{i_1} \cdots x_{i_l} = y_{i_1} \cdots y_{i_l}$,}\\[1ex]
+\narrowcentering{$x_{i_1} \cdots x_{i_\ell} = y_{i_1} \cdots y_{i_\ell}$,}\\[1ex]
 wobei $\ell>0$ ist und $i_j\in\{1,\ldots,k\}$ für alle $j=1,\ldots,\ell$?
 }
 


### PR DESCRIPTION
Was ist i_k? 
Wenn die erfüllende Folge von Zahlen von i_1 bis i_l geht, sollten auch die entstehenden Wörter von x_{i_1} bis x_{i_l} bzw.  y_{i_1} bis y_{i_l} gehen.